### PR TITLE
auto-deletion: delete old recordings by count threshold (FIFO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ Later, this recording might be deleted in memory and physically by the scheduler
 
 ### Auto-deletion process
 
-There is a process to delete automatically the recording files (whose status are STOPPED or CLOSED) periodically
-according the following property
+IMPORTANT: Be aware that the main app should be annotated with @EnableScheduling to enable the scheduled processes for auto-deletion.
+
+The process periodically deletes recording files, which are in status `STOPPED` or `CLOSED`. The cleanup interval can be configured via
 
 ```properties
 flightrecorder.recording-cleanup-interval=5000
@@ -188,18 +189,34 @@ flightrecorder.recording-cleanup-interval=5000
 
 with default value set on 5000ms. The base unit is MILLISECONDS. Take into account that the deletion is permanently.
 
-The watermark used to annotate a recording as "removable" is the start time, The threshold is configured via the
-properties below:
+The watermark used to annotate a recording as "removable" is either time-based (TTL) or count-based (COUNT).
+
+The default cleanup type is `TTL` and can be changed using the property:
+```properties
+flightrecorder.recording-cleanup-type=COUNT
+```
+
+#### Deletion by TTL
+
+If the cleanup type is `TTL` (time to live), the recording's start time represents the reference point for the TTL deletion. The threshold can be configured via the properties below (default: 1 Hour):
 
 ```properties
 flightrecorder.old-recordings-TTL=1
 flightrecorder.old-recordings-TTL-time-unit=Hours  # java.time.temporal.ChronoUnit available values
 ```
 
-A file will be removed when the status are STOPPED or CLOSED, and the start time is before than now minus threshold
-configured.
+A file will be removed when the status is `STOPPED` or `CLOSED`, and the recording's start time is before _now_ minus _threshold configured_.
 
-IMPORTANT: Be aware that the main app should be annotated with @EnableScheduling to enable the scheduled processes.
+#### Deletion by COUNT
+
+If the cleanup type is `COUNT`, the oldest recordings will be deleted when the total number of existing recordings surpasses the configured threshold of recordings to keep. The threshold can be configured via the property below (default: 10 recordings):
+
+```properties
+flightrecorder.old-recordings-max=10
+```
+
+A file will be removed when the status is `STOPPED` or `CLOSED`, based on a FIFO logic.
+
 
 ## Trigger Flight Recording based on Micrometer Metrics
 

--- a/src/main/java/de/mirkosertic/flightrecorderstarter/configuration/FlightRecorderDynamicConfiguration.java
+++ b/src/main/java/de/mirkosertic/flightrecorderstarter/configuration/FlightRecorderDynamicConfiguration.java
@@ -33,6 +33,7 @@ public class FlightRecorderDynamicConfiguration {
     private CleanupType recordingCleanupType;
     private long oldRecordingsTTL;
     private ChronoUnit oldRecordingsTTLTimeUnit;
+    private int oldRecordingsMax;
     private String jfrBasePath;
     private String jfrCustomConfig;
 
@@ -68,6 +69,14 @@ public class FlightRecorderDynamicConfiguration {
 
     public void setOldRecordingsTTLTimeUnit(final ChronoUnit oldRecordingsTTLTimeUnit) {
         this.oldRecordingsTTLTimeUnit = oldRecordingsTTLTimeUnit;
+    }
+
+    public int getOldRecordingsMax() {
+        return this.oldRecordingsMax;
+    }
+
+    public void setOldRecordingsMax(int oldRecordingsMax) {
+        this.oldRecordingsMax = oldRecordingsMax;
     }
 
     public List<Trigger> getTrigger() {

--- a/src/main/java/de/mirkosertic/flightrecorderstarter/configuration/FlightRecorderDynamicConfiguration.java
+++ b/src/main/java/de/mirkosertic/flightrecorderstarter/configuration/FlightRecorderDynamicConfiguration.java
@@ -24,7 +24,13 @@ import java.util.List;
 @ConfigurationProperties(prefix = "flightrecorder")
 public class FlightRecorderDynamicConfiguration {
 
+    public enum CleanupType {
+        TTL,
+        COUNT
+    }
+
     private boolean enabled = true;
+    private CleanupType recordingCleanupType;
     private long oldRecordingsTTL;
     private ChronoUnit oldRecordingsTTLTimeUnit;
     private String jfrBasePath;
@@ -38,6 +44,14 @@ public class FlightRecorderDynamicConfiguration {
 
     public void setEnabled(final boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public CleanupType getRecordingCleanupType() {
+        return recordingCleanupType;
+    }
+
+    public void setRecordingCleanupType(String recordingCleanupType) {
+        this.recordingCleanupType = CleanupType.valueOf(recordingCleanupType);
     }
 
     public long getOldRecordingsTTL() {

--- a/src/main/java/de/mirkosertic/flightrecorderstarter/core/FlightRecorder.java
+++ b/src/main/java/de/mirkosertic/flightrecorderstarter/core/FlightRecorder.java
@@ -169,8 +169,8 @@ public class FlightRecorder {
                 deletableRecordings = getDeletableRecordingsByTTL();
             } else if (this.configuration.getRecordingCleanupType() == FlightRecorderDynamicConfiguration.CleanupType.COUNT) {
                 deletableRecordings = getDeletableRecordingsByCount();
-            } else {
-                throw new IllegalStateException(String.format("Unknown CleanupType '%s'. Deletion failed.", this.configuration.getRecordingCleanupType()));
+            } else { // can only happen in tests if cleanupType is not set
+                throw new IllegalArgumentException(String.format("Unknown CleanupType '%s'. Deletion failed.", this.configuration.getRecordingCleanupType()));
             }
 
             deletableRecordings.forEach(this::deleteRecording);

--- a/src/main/resources/flight-recorder.properties
+++ b/src/main/resources/flight-recorder.properties
@@ -3,5 +3,6 @@ management.endpoints.web.exposure.include=*
 flightrecorder.calculated-static-controller-base-path=${management.endpoints.web.base-path:actuator}/flightrecorder/ui/
 flightrecorder.trigger-check-interval=10000
 flightrecorder.recording-cleanup-interval=5000
+flightrecorder.recording-cleanup-type=TTL
 flightrecorder.old-recordings-TTL=1
 flightrecorder.old-recordings-TTL-time-unit=Hours

--- a/src/main/resources/flight-recorder.properties
+++ b/src/main/resources/flight-recorder.properties
@@ -6,3 +6,4 @@ flightrecorder.recording-cleanup-interval=5000
 flightrecorder.recording-cleanup-type=TTL
 flightrecorder.old-recordings-TTL=1
 flightrecorder.old-recordings-TTL-time-unit=Hours
+flightrecorder.old-recordings-max=10

--- a/src/test/java/de/mirkosertic/flightrecorderstarter/core/FlightRecorderTest.java
+++ b/src/test/java/de/mirkosertic/flightrecorderstarter/core/FlightRecorderTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static de.mirkosertic.flightrecorderstarter.configuration.FlightRecorderDynamicConfiguration.CleanupType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.BDDMockito.given;
@@ -398,11 +399,10 @@ class FlightRecorderTest {
 
         then(recordings).should(never()).remove(any());
         assertThat(recordings.size()).isEqualTo(0);
-
     }
 
     @Test
-    void givenSingleRecordingSessionClosed_whenCleanUpProcessIsExecuted_thenThatRecordingSessionIsDeleted() {
+    void givenSingleRecordingSessionClosed_whenCleanUpProcessIsExecutedByTTL_thenThatRecordingSessionIsDeleted() {
         //  + one recording candidate closed -> delete candidate
 
         //given
@@ -423,6 +423,7 @@ class FlightRecorderTest {
 
 
         final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.TTL.toString());
         configuration.setOldRecordingsTTL(1);
         configuration.setOldRecordingsTTLTimeUnit(ChronoUnit.SECONDS);
         final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
@@ -438,7 +439,7 @@ class FlightRecorderTest {
     }
 
     @Test
-    void givenSingleRecordingSessionStopped_whenCleanUpProcessIsExecuted_thenThatRecordingSessionIsDeleted() {
+    void givenSingleRecordingSessionStopped_whenCleanUpProcessIsExecutedByTTL_thenThatRecordingSessionIsDeleted() {
         //  + one recording candidate stopped -> close candidate and delete candidate
 
 
@@ -459,6 +460,7 @@ class FlightRecorderTest {
         given(mockFile.delete()).willReturn(true);
 
         final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.TTL.toString());
         configuration.setOldRecordingsTTL(1);
         configuration.setOldRecordingsTTLTimeUnit(ChronoUnit.SECONDS);
         final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
@@ -475,7 +477,7 @@ class FlightRecorderTest {
 
 
     @Test
-    void givenSingleRecordingSessionClosedNoCandidate_whenCleanUpProcessIsExecuted_thenThatRecordingSessionIsNotDeleted() {
+    void givenSingleRecordingSessionClosedNoCandidate_whenCleanUpProcessIsExecutedByTTL_thenThatRecordingSessionIsNotDeleted() {
         //  + one recording no candidate (starttime) -> no delete recording
 
 
@@ -490,6 +492,7 @@ class FlightRecorderTest {
         given(mockRecording.getStartTime()).willReturn(Instant.now().minusSeconds(1));
 
         final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.TTL.toString());
         configuration.setOldRecordingsTTL(10);
         configuration.setOldRecordingsTTLTimeUnit(ChronoUnit.SECONDS);
         final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
@@ -506,7 +509,7 @@ class FlightRecorderTest {
 
 
     @Test
-    void givenSingleRecordingSessionRunningNoCandidate_whenCleanUpProcessIsExecuted_thenThatRecordingSessionIsNotDeleted() {
+    void givenSingleRecordingSessionRunningNoCandidate_whenCleanUpProcessIsExecutedByTTL_thenThatRecordingSessionIsNotDeleted() {
         //  + one recording no candidate (status running) -> no delete recording
 
 
@@ -521,6 +524,7 @@ class FlightRecorderTest {
         given(mockRecording.getStartTime()).willReturn(Instant.now().minusSeconds(10));
 
         final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.TTL.toString());
         configuration.setOldRecordingsTTL(1);
         configuration.setOldRecordingsTTLTimeUnit(ChronoUnit.SECONDS);
         final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
@@ -536,7 +540,7 @@ class FlightRecorderTest {
     }
 
     @Test
-    void givenOneCandidateOfTwoRecordingSession_whenCleanUpProcessIsExecuted_thenJustOnlyOneRecordingSessionIsDeleted() {
+    void givenOneCandidateOfTwoRecordingSession_whenCleanUpProcessIsExecutedByTTL_thenJustOnlyOneRecordingSessionIsDeleted() {
         //  + two recording, one candidate one no -> delete only the candidate
 
         //given
@@ -567,6 +571,7 @@ class FlightRecorderTest {
 
 
         final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.TTL.toString());
         configuration.setOldRecordingsTTL(1);
         configuration.setOldRecordingsTTLTimeUnit(ChronoUnit.SECONDS);
         final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
@@ -584,7 +589,7 @@ class FlightRecorderTest {
     }
 
     @Test
-    void givenTwoRecordingSessionCandidate_whenCleanUpProcessIsExecuted_thenAllRecordingSessionIsDeleted() {
+    void givenTwoRecordingSessionCandidate_whenCleanUpProcessIsExecutedByTTL_thenAllRecordingSessionIsDeleted() {
         //  + two recording candidates -> delete all the candidates
 
         //given
@@ -615,6 +620,7 @@ class FlightRecorderTest {
 
 
         final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.TTL.toString());
         configuration.setOldRecordingsTTL(1);
         configuration.setOldRecordingsTTLTimeUnit(ChronoUnit.SECONDS);
         final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
@@ -627,8 +633,6 @@ class FlightRecorderTest {
         then(recordings).should().remove(idTest1);
         then(recordings).should().remove(idTest2);
         assertThat(recordings.size()).isEqualTo(0);
-
-
     }
 
 

--- a/src/test/java/de/mirkosertic/flightrecorderstarter/core/FlightRecorderTest.java
+++ b/src/test/java/de/mirkosertic/flightrecorderstarter/core/FlightRecorderTest.java
@@ -8,6 +8,8 @@ import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.system.SystemProperties;
 
 import java.io.File;
@@ -25,6 +27,7 @@ import java.util.Map;
 import static de.mirkosertic.flightrecorderstarter.configuration.FlightRecorderDynamicConfiguration.CleanupType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
@@ -381,14 +384,81 @@ class FlightRecorderTest {
     }
 
     @Test
-    void givenNoneRecordingSessions_whenCleanUpProcessIsExecuted_thenNothingHappened() {
+    void givenConfigurationCleanupByTTL_whenCleanupOldRecordings_thenCleanupByTTL() {
+        //given
+        final Map<Long, RecordingSession> recordings = spy(new HashMap<>());
+        final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.TTL.toString());
+        configuration.setOldRecordingsTTL(1);
+        configuration.setOldRecordingsTTLTimeUnit(ChronoUnit.SECONDS);
+
+        final FlightRecorder flightRecorder = spy(new FlightRecorder(configuration, recordings));
+
+        //when
+        flightRecorder.cleanupOldRecordings();
+
+        //then
+        verify(flightRecorder, times(1)).getDeletableRecordingsByTTL();
+        verify(flightRecorder, never()).getDeletableRecordingsByCount();
+    }
+
+    @Test
+    void givenConfigurationCleanupByCount_whenCleanupOldRecordings_thenCleanupByCount() {
+        //given
+        final Map<Long, RecordingSession> recordings = spy(new HashMap<>());
+        final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.COUNT.toString());
+        configuration.setOldRecordingsMax(2);
+
+        final FlightRecorder flightRecorder = spy(new FlightRecorder(configuration, recordings));
+
+        //when
+        flightRecorder.cleanupOldRecordings();
+
+        //then
+        verify(flightRecorder, times(1)).getDeletableRecordingsByCount();
+        verify(flightRecorder, never()).getDeletableRecordingsByTTL();
+    }
+
+    /**
+     * In reality, the service would not start if the cleanupType is misconfigured,
+     * and log the faulty application.properties value instead.
+     * In tests, the cleanupType must be set manually.
+     * If not set, a test will only fail, if an exception is thrown at runtime.
+     * This test asserts this behavior.
+     */
+    @Test
+    void givenConfigurationUnknownCleanupType_whenCleanupOldRecordings_thenThrows() {
+        //given
+        final Map<Long, RecordingSession> recordings = spy(new HashMap<>());
+        final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        // recordingCleanupType explicity not set
+
+        final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
+
+        //when/then
+        assertThrows(IllegalArgumentException.class, flightRecorder::cleanupOldRecordings);
+    }
+
+    @ValueSource(strings = {
+            "TTL",
+            "COUNT"
+    })
+    @ParameterizedTest
+    void givenNoneRecordingSessions_whenCleanUpProcessIsExecuted_thenNothingHappened(String cleanupType) {
         //  + no recordings -> deletionservice is not invoked
 
         //given
         final Map<Long, RecordingSession> recordings = spy(new HashMap<>());
         final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
-        configuration.setOldRecordingsTTL(1);
-        configuration.setOldRecordingsTTLTimeUnit(ChronoUnit.SECONDS);
+        configuration.setRecordingCleanupType(cleanupType);
+        if (configuration.getRecordingCleanupType() == CleanupType.TTL) {
+            configuration.setOldRecordingsTTL(1);
+            configuration.setOldRecordingsTTLTimeUnit(ChronoUnit.SECONDS);
+        }
+        if (configuration.getRecordingCleanupType() == CleanupType.COUNT) {
+            configuration.setOldRecordingsMax(2);
+        }
         final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
 
 
@@ -473,6 +543,79 @@ class FlightRecorderTest {
         then(recordings).should().remove(idTest);
         assertThat(recordings.size()).isEqualTo(0);
 
+    }
+
+    @Test
+    void givenMultipleRecordingSessionsStopped_whenCleanUpProcessIsExecutedByCount_thenRecordingSessionsAboveThresholdAreDeleted() {
+
+        //given
+        final long id1 = 1L;
+        final long id2 = 2L;
+        final Map<Long, RecordingSession> recordings = spy(new HashMap<>());
+        final Recording mockRecording = mock(Recording.class);
+        final RecordingSession recordingSession = new RecordingSession(mockRecording, "");
+        recordings.put(id1, recordingSession);
+        recordings.put(id2, recordingSession);
+        recordings.put(3L, recordingSession);
+        recordings.put(4L, recordingSession);
+
+        given(mockRecording.getState()).willReturn(RecordingState.STOPPED);
+        given(mockRecording.getStartTime()).willReturn(Instant.now().minusSeconds(10));
+
+        final File mockFile = mock(File.class);
+        final Path mockPath = mock(Path.class);
+        given(mockRecording.getDestination()).willReturn(mockPath);
+        given(mockPath.toFile()).willReturn(mockFile);
+        given(mockFile.delete()).willReturn(true);
+
+        final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.COUNT.toString());
+        configuration.setOldRecordingsMax(2);
+        final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
+
+        //when
+        flightRecorder.cleanupOldRecordings();
+
+        //then
+        then(mockRecording).should(atLeastOnce()).close();
+        then(recordings).should().remove(id1);
+        then(recordings).should().remove(id2);
+        assertThat(recordings).hasSize(2);
+    }
+
+    @Test
+    void givenMultipleRecordingSessionsStoppedAndCountBelowOrEqualToThreshold_whenCleanUpProcessIsExecutedByCount_thenNoRecordingSessionsAreDeleted() {
+
+        //given
+        final long id1 = 1L;
+        final long id2 = 2L;
+        final Map<Long, RecordingSession> recordings = spy(new HashMap<>());
+        final Recording mockRecording = mock(Recording.class);
+        final RecordingSession recordingSession = new RecordingSession(mockRecording, "");
+        recordings.put(id1, recordingSession);
+        recordings.put(id2, recordingSession);
+
+        given(mockRecording.getState()).willReturn(RecordingState.STOPPED);
+        given(mockRecording.getStartTime()).willReturn(Instant.now().minusSeconds(10));
+
+        final File mockFile = mock(File.class);
+        final Path mockPath = mock(Path.class);
+        given(mockRecording.getDestination()).willReturn(mockPath);
+        given(mockPath.toFile()).willReturn(mockFile);
+        given(mockFile.delete()).willReturn(true);
+
+        final FlightRecorderDynamicConfiguration configuration = new FlightRecorderDynamicConfiguration();
+        configuration.setRecordingCleanupType(CleanupType.COUNT.toString());
+        configuration.setOldRecordingsMax(2);
+        final FlightRecorder flightRecorder = new FlightRecorder(configuration, recordings);
+
+        //when
+        flightRecorder.cleanupOldRecordings();
+
+        //then
+        then(recordings).should(never()).remove(id1);
+        then(recordings).should(never()).remove(id2);
+        assertThat(recordings).hasSize(2);
     }
 
 


### PR DESCRIPTION
# Feature proposal - auto-delete recordings by count-threshold - WIP

Similar to auto-deletion by time-threshold (call it TTL from here on), recordings should be deletable by a configured count-threshold (COUNT).

Based on FIFO, oldest recordings are deleted, if they are above the defined count of recordings to keep.

This change should be backward compatible, i.e. it shouldn't break existing functionality or configuration, since I set the existing auto-deletion functionality as default. Please verify.

## Motivation

If a recording was created via a micrometer metric trigger, the recordings should be available for download.
If such a trigger event occurred at night, the recording would be gone by the next morning if TTL deletion is used.
Disabling the auto-deletion by TTL is not possible, as the disc space in cloud applications is usually limited (either by physical or monetary limitations).
Thus, an auto-deletion approach is needed that does not delete the recordings too quickly, but also takes availabe disc space into account.

This Pull Request addresses the requirements just explained.


## Self-disclosure:
I am employed at [**SAP SE**](https://www.sap.com/) and I have implemented this proposed feature in my role as a _SAP backend developer_.

_Copyright (c) 2022 SAP SE_